### PR TITLE
Embed YT videos

### DIFF
--- a/1_video3_2_level_illustration.Rmd
+++ b/1_video3_2_level_illustration.Rmd
@@ -2,7 +2,9 @@
 
 ## Relating two-stage random effects to simulated data and model output {.unlisted}
 
-
+<div class="containeryt">
+<iframe class="videoyt" src="https://www.youtube.com/embed/OL6UezgpmPo?list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
 ## Introduction 
 This chapter accompanies the 3rd video in the series, ["Simulating data using the 2-stage random effects formulation"](https://youtu.be/OL6UezgpmPo). The purpose of this chapter is to help in understanding the two-stage random effects formulation for mixed models by simulating data based on the formulation, analyzing the simulated data and comparing the two.  This is a great way to wrap your head around what a mixed model is doing.  This is written under the assumption that you have seen the first few videos in the [Mixed Models series](https://www.youtube.com/watch?v=IGHm1XHFWMc&list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z)  on the MumfordBrainStats YouTube channel.  If you haven't, go look for that playlist and watch those first.  As discussed in the videos, this is not a perfect setup for the mixed models and not all mixed models can fit into this formulation, but it is a great way to understand mixed models.  Sometimes it is helpful to see how repeated measures data are simulated in order to understand what the model is doing.  In this case the values in the simulation will show up again when the data are fit using the lmer() function.  Make sure to spend time matching up the values in the simulation code with the lmer output to increase your understanding of mixed models.  

--- a/2_video4_two_stage_temptation.Rmd
+++ b/2_video4_two_stage_temptation.Rmd
@@ -2,6 +2,10 @@
 
 ## What is this regularization and why don't we analyze the data in 2 stages? {.unlisted}
 
+<div class="containeryt">
+<iframe class="videoyt" src="https://www.youtube.com/embed/sRhFeC-STdw?list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 ## Introduction
 
 This chapter is paired with the fourth video in the mixed model series, [What is this regularization and why don't we analyze the data in 2 stages?](https://youtu.be/sRhFeC-STdw). Although the two-stage formulation is a great way to conceptualize the mixed model, it also might inspire a shortcut for data analysis: the two-stage summary statistics approach.  For those familiar with fMRI data, this is exactly what is done to analyze those data due to the complexity and structure of the data.  The approaches vary greatly across software packages where the SPM approach is most similar to what will be done here, but I will not be making comparisons with or between fMRI software.  There is a [related paper](https://www.ncbi.nlm.nih.gov/pubmed/19463958), written by myself and others that compares the models of different fMRI software packages.  

--- a/3_video5_win_sub_mns_vs_cond_modes.Rmd
+++ b/3_video5_win_sub_mns_vs_cond_modes.Rmd
@@ -2,6 +2,10 @@
 
 ## Relationship between mixed model conditional modes (aka BLUPS) and OLS estimates {.unlisted}
 
+<div class="containeryt">
+<iframe class="videoyt" src="https://www.youtube.com/embed/QqEUKlKPos4?list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 ## Introduction
 
 This chapter accompanies the fifth video in the mixed models series,   ["Relationship between mixed model conditional modes (aka BLUPS) and OLS estimates"](https://youtu.be/QqEUKlKPos4).

--- a/4_video6_group_comparison_three_models.Rmd
+++ b/4_video6_group_comparison_three_models.Rmd
@@ -2,6 +2,9 @@
 
 ## Group differences of within-subject averages: How do modeling approaches compare with unequal groups and unequal observations within-subject? {.unlisted}
 
+<div class="containeryt">
+<iframe class="videoyt" src="https://www.youtube.com/embed/C4r20a_pqlA?list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
 ## Introduction
 This chapter accompanies the 6th video in the series, ["Can the regularization in mixed models be problematic?"](https://youtu.be/C4r20a_pqlA).  Previous chapters focused on the regularization built into a mixed model. As I mentioned earlier, when I explained this to a colleague of mine, she asked how the regularization would impact her results.  She's studying a patient group that tends to be much smaller than her control group and often she also has less data per subject in her patient group.  Will the regularization of the mixed model hurt her power to detect group differences?  In this chapter I focus on different approaches to modeling the data (mixed models, 2SSS and two pseudo 2SSS approaches) to investigate type I error and power when data are both balanced and unbalanced within-group and within-subject.  Additionally, these simulations will address my previous comments about why the conditional modes are not the perfect way of viewing regularization.

--- a/index.Rmd
+++ b/index.Rmd
@@ -20,7 +20,7 @@ description: ""
 knitr::include_graphics("./images/mixed_model_book_cover.png")
 ```
 
-This is a collection of materials that accompanies a [YouTube series on the MumfordBrainStats channel about mixed models](https://www.youtube.com/watch?v=IGHm1XHFWMc&list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z).  Although I normall focus on material related to neuroimaging, this is for a general audience.  Each of these chapters should be understandable without watching the video, but one would probably gain the most by watching the videos as well.  The chapter titles indicate which video in the series goes along with that chapter.   Not all videos have chapter (yet), since I'm only including chapters with code for now.  In the future I may try to smooth this out more to read more like an actual book.
+This is a collection of materials that accompanies a [YouTube series on the MumfordBrainStats channel about mixed models](https://www.youtube.com/watch?v=IGHm1XHFWMc&list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z).  Although I normally focus on material related to neuroimaging, this is for a general audience.  Each of these chapters should be understandable without watching the video, but one would probably gain the most by watching the videos as well.  The chapter titles indicate which video in the series goes along with that chapter.   Not all videos have chapter (yet), since I'm only including chapters with code for now.  In the future I may try to smooth this out more to read more like an actual book.
 
 Although this series isn't necessarily set up to be a tutorial on how to run a mixed model properly, it would still be useful for somebody who is new to mixed models.  I'm focusing on odds and ends that I've seen come up that I feel are less frequently discussed.  Basically mistakes I've made or seen that I'd like to help you avoid.  Interestingly, many of these mistakes are made by those with some knowledge of mixed models.  I think they often arises from  a "knows enough to be dangerous" situation.  Do not misinterpret that as it is good to be dangerous, brave, make mistakes and then fix them.  That's how we learn!
 
@@ -35,3 +35,16 @@ Specific goals of this series:
 This series is still in development.  Future topics will involve: crossed/nested random effects, tips for planning out your analysis setup, simplifying random effects structures (when is it okay) and hopefully some examples from the audience of this series about their trials and tribulations with mixed models.  I'm also looking for solid ways to test model assumptions.  So far I haven't found anything super satisfying.
 
 For feedback, you can find me on twitter: @mumbrainstats.
+
+## V0 - Introduction video {-}
+
+`r knitr::include_url("https://www.youtube.com/embed/IGHm1XHFWMc?list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z")`
+
+## V1 - Regression review video {-}
+`r knitr::include_url("https://www.youtube.com/embed/5D5zEA29tu4?list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z")`
+
+## V2 - Two stage random effects formulation {-}
+
+<div class="containeryt">
+<iframe class="videoyt" src="https://www.youtube.com/embed/1P_AtGjC5j4?list=PLB2iAtgpI4YEAUiEQ1ZnfMXY-yewNzn9z" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>

--- a/style.css
+++ b/style.css
@@ -13,3 +13,17 @@ pre {
 pre code {
   white-space: inherit;
 }
+
+.containeryt {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+}
+.videoyt {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
Hi, 

I really really liked your MM series, and I thought it could be improved if watchers could go to only one link for the videos and materials.

There are two ways to embed YT vide; there is the one-liner option with knitr::include_url, but no fullscreen is possible with this option (AFAIK).

To enable fullscreen videos, I had to add some CSS classes and include the iframe within a *div container*. This way, the iframe takes 100% of the width, and the height gets adjusted proportionally. 

I included both solutions (in `index.Rmd`) in case you prefer one over the other. As a watcher, I feel the second one with fullscreen makes it more enjoyable.

Feel free to merge the PR or not.
(Sidenote: I tested and rendered the index.Rmd, but not the *3_video5...* and *4_video6...* .Rmd files because they took forever to [not] render on my laptop.)

Thanks again. I greatly appreciate your work. 